### PR TITLE
fix: csrf middleware

### DIFF
--- a/functions/src/middlewares/csrf_middleware.ts
+++ b/functions/src/middlewares/csrf_middleware.ts
@@ -26,15 +26,22 @@ export const csrfProtection: RequestHandler = (
   }
 
   const csrfCookie = req.cookies?.["CSRF-TOKEN"] as string | undefined;
-  const csrfHeader = req.header("x-csrf-token");
+  const csrfHeader = req.header("x-xsrf-token");
 
-  functions.logger.log("CSRF Cookie:", csrfCookie);
-  functions.logger.log("CSRF Header:", csrfHeader);
-
-  if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {
+  if (!csrfCookie || !csrfHeader) {
     functions.logger.log(
-      "CSRF validation rejected as cookie and header does not match."
+      "CSRF validation rejected: Missing token in cookie or header"
     );
+    res
+      .status(403)
+      .json({ status: 403, error: "CSRF token validation failed" });
+    return;
+  }
+
+  if (
+    !crypto.timingSafeEqual(Buffer.from(csrfCookie), Buffer.from(csrfHeader))
+  ) {
+    functions.logger.log("CSRF validation rejected: Token mismatch");
     res
       .status(403)
       .json({ status: 403, error: "CSRF token validation failed" });
@@ -45,5 +52,15 @@ export const csrfProtection: RequestHandler = (
 };
 
 export const generateCsrfToken = (): string => {
-  return crypto.randomBytes(16).toString("hex");
+  return crypto.randomBytes(32).toString("hex");
+};
+
+export const setCsrfCookie = (res: Response, token: string): void => {
+  res.cookie("CSRF-TOKEN", token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/",
+    maxAge: 24 * 60 * 60 * 1000,
+  });
 };


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Rename CSRF header to `x-xsrf-token`

- Add timingSafeEqual for token comparison

- Increase CSRF token length to 32 bytes

- Introduce `setCsrfCookie` helper function


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>csrf_middleware.ts</strong><dd><code>Improve CSRF token validation and handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

functions/src/middlewares/csrf_middleware.ts

<li>Renamed header check from <code>x-csrf-token</code> to <code>x-xsrf-token</code><br> <li> Replaced basic equality with timingSafeEqual comparison<br> <li> Increased generated token size from 16 to 32 bytes<br> <li> Added <code>setCsrfCookie</code> for secure cookie handling


</details>


  </td>
  <td><a href="https://github.com/GarudaHacks/web-be/pull/25/files#diff-e21be0d7591c1a9d2b018e60a519a6bbf0e07c3b2eff8b0bf0548987548a01f0">+24/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>